### PR TITLE
FEAT: add lookback time and absorption distance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ write_to = "wcosmo/_version.py"
 [project.entry-points."gwpopulation.xp"]
 wcosmo = "wcosmo.wcosmo"
 wcosmo-utils = "wcosmo.utils"
+wcosmo-taylor = "wcosmo.taylor"
 
 [project.entry-points."gwpopulation.other"]
-wcosmo-utils = "wcosmo.utils:scipy.linalg.toeplitz"
+wcosmo-taylor = "wcosmo.taylor:scipy.linalg.toeplitz"

--- a/wcosmo/taylor.py
+++ b/wcosmo/taylor.py
@@ -1,0 +1,210 @@
+r"""
+Utilities based on the Taylor expansion of the functions of the form
+:math:`\frac{(1 + z)^k}{E(z)}` for flat wCDM cosmology.
+These functions and their integral are estimated using the Pade approximation.
+"""
+
+import numpy as xp
+from scipy.linalg import toeplitz
+
+from .utils import autodoc
+
+__all__ = [
+    "analytic_integral",
+    "flat_wcdm_pade_coefficients",
+    "flat_wcdm_taylor_expansion",
+]
+
+
+def pade(an, m, n=None):
+    """
+    Return Pade approximation to a polynomial as the ratio of two polynomials.
+
+    Parameters
+    ----------
+    an : (N,) array_like
+        Taylor series coefficients.
+    m : int
+        The order of the returned approximating polynomial `q`.
+    n : int, optional
+        The order of the returned approximating polynomial `p`. By default,
+        the order is ``len(an)-1-m``.
+
+    Returns
+    -------
+    p, q : Polynomial class
+        The Pade approximation of the polynomial defined by `an` is
+        ``p(x)/q(x)``.
+
+    Notes
+    -----
+    This code has been slightly edited from the scipy implementation to:
+
+    - Use xp instead of np to support multiple backends
+    - Directly use the fact that part of the matrix is Toeplitz
+
+    """
+    an = xp.asarray(an)
+    if n is None:
+        n = len(an) - 1 - m
+        if n < 0:
+            raise ValueError("Order of q <m> must be smaller than len(an)-1.")
+    if n < 0:
+        raise ValueError("Order of p <n> must be greater than 0.")
+    N = m + n
+    if N > len(an) - 1:
+        raise ValueError("Order of q+p <m+n> must be smaller than len(an).")
+    an = an[: N + 1]
+    Akj = xp.eye(N + 1, n + 1, dtype=an.dtype)
+    Bkj = toeplitz(xp.r_[0.0, -an[:-1]], xp.zeros(m))
+    Ckj = xp.hstack((Akj, Bkj))
+    pq = xp.linalg.solve(Ckj, an)
+    p = pq[: n + 1]
+    q = xp.r_[1.0, pq[n + 1 :]]
+    return p[::-1], q[::-1]
+
+
+@autodoc
+def flat_wcdm_taylor_expansion(w0, zpower=0):
+    r"""
+    Taylor coefficients expansion of :math:`E(z)` as as a function
+    of :math:`w_0` and an arbitrary power :math:`k` of :math:`1 + z`.
+
+    .. math::
+
+        F(x; w_0; k) = 2\sum_{{n=0}}^{{\infty}} \binom{{-\frac{{1}}{{2}}}}{{n}}
+        \frac{{x^n}}{{\left(1 - 2k - 6nw_0\right)}}
+
+    We include terms up to :math:`n=16`.
+
+    Parameters
+    ----------
+    {w0}
+    {zpower}
+
+    Returns
+    -------
+    array_like
+        The Taylor expansion coefficients.
+    """
+    power = 1 - 2 * zpower
+    return xp.array(
+        [
+            w0**0 / power,
+            -1 / (2 * (power - 6 * w0)),
+            3 / (8 * (power - 12 * w0)),
+            -5 / (16 * (power - 18 * w0)),
+            35 / (128 * (power - 24 * w0)),
+            -63 / (256 * (power - 30 * w0)),
+            231 / (1024 * (power - 36 * w0)),
+            -429 / (2048 * (power - 42 * w0)),
+            6435 / (32768 * (power - 48 * w0)),
+            -12155 / (65536 * (power - 54 * w0)),
+            46189 / (262144 * (power - 60 * w0)),
+            -88179 / (524288 * (power - 66 * w0)),
+            676039 / (4194304 * (power - 72 * w0)),
+            -1300075 / (8388608 * (power - 78 * w0)),
+            5014575 / (33554432 * (power - 84 * w0)),
+            -9694845 / (67108864 * (power - 90 * w0)),
+            300540195 / (268435456 * (power - 96 * w0)),
+        ]
+    )
+
+
+@autodoc
+def flat_wcdm_pade_coefficients(w0=-1, zpower=0):
+    """
+    Compute the Pade coefficients as described in arXiv:1111.6396.
+    We make two primary changes:
+
+    - allow a variable dark energy equation of state :math:`w_0` by changing
+      the definition of :math:`x`.
+    - include more terms (17) in the Taylor expansion.
+
+    Parameters
+    ----------
+    {w0}
+
+    Returns
+    -------
+    p, q: array_like
+        The Pade coefficients
+    """
+    coeffs = flat_wcdm_taylor_expansion(w0, zpower=zpower)
+    p, q = pade(coeffs, len(coeffs) // 2, len(coeffs) // 2)
+    return p, q
+
+
+@autodoc
+def indefinite_integral(z, Om0, w0=-1, zpower=0):
+    r"""
+    Compute the Pade approximation to :math:`(1+z)^k / E(z)` as described in
+    arXiv:1111.6396. We extend it to include a variable dark energy
+    equation of state, other integrands via powers of :math:`1 + z` and
+    include more terms in the expansion
+
+    .. math::
+
+        I(z; \Omega_{{m, 0}}, w_0) = \frac{{-2 (1 + z)^{{\frac{{1}}{{2}}-k}}}}
+        {{\Omega_{{m, 0}}^{{\frac{{1}}{{2}}}}}} \Phi(z; \Omega_{{m, 0}}, w_0).
+    
+    .. math::
+
+        \Phi(z; \Omega_{{m, 0}}, w_0) =
+        \frac{{\sum_i^n \alpha_i x^i}}{{1 + \sum_{{j=1}}^m \beta_j x^j}}.
+
+    Here the expansion is in terms of
+
+    .. math::
+
+        x = \left(\frac{{1 - \Omega_{{m, 0}}}}{{\Omega_{{m, 0}}}}\right)
+        (1 + z)^{{3 w_0}}.
+
+    In practice we use :math:`m=n=7` whereas Adachi and Kasai use :math:`m=n=3`.
+
+    Parameters
+    ----------
+    {z}
+    {Om0}
+    {w0}
+
+    Returns
+    -------
+    I: array_like
+        The indefinite integral of :math:`(1+z)^k / E(z)`
+    """
+    x = (1 - Om0) / Om0 * (1 + z) ** (3 * w0)
+    p, q = flat_wcdm_pade_coefficients(w0=w0, zpower=zpower)
+    normalization = -2 / Om0**0.5 / (1 + z) ** (0.5 - zpower)
+    return normalization * xp.polyval(p, x) / xp.polyval(q, x)
+
+
+@autodoc
+def analytic_integral(z, Om0, w0=-1, zpower=0):
+    r"""
+    Compute an integral of the form
+    :math:`\int_{{\infty}}^z \frac{{(1+z)^k}}{{E(z)}}` using
+
+    .. math::
+
+        f(z; \Omega_{{m, 0}}, w_0) = \int_{{\infty}}^{{z}}
+        \frac{{dz' (1 + z')^k}}{{E(z'; \Omega_{{m, 0}}, w_0)}}
+        = \frac{{-2\Phi(z; \Omega_{{m, 0}}, w_0) (1+z)^k }}
+        {{\sqrt{{\Omega_{{m, 0}}(1 + z)}}}}.
+
+    The integral is approximated using the Pade approximation and is up
+    to a factor the term in the braces in (1.1) of Adachi and Kasai.
+
+    Parameters
+    ----------
+    {z}
+    {Om0}
+    {w0}
+
+    Returns
+    -------
+    integral: array_like
+        The integral of :math:`1 / E(z)` from :math:`\infty` to :math:`z`
+    """
+    kwargs = dict(Om0=Om0, w0=w0, zpower=zpower)
+    return indefinite_integral(z, **kwargs) - indefinite_integral(0, **kwargs)

--- a/wcosmo/utils.py
+++ b/wcosmo/utils.py
@@ -3,8 +3,6 @@ Helper functions that are not directly relevant to cosmology.
 """
 
 import numpy as xp
-from scipy.linalg import toeplitz
-
 
 _cosmology_docstrings_ = dict(
     z="""z: array_like
@@ -36,10 +34,16 @@ _cosmology_docstrings_ = dict(
         The secondary mass in the detector frame""",
     dL="""dL: array_like
         The luminosity distance in Mpc""",
+    zpower="""zpower: array_like
+        The power of the redshift dependence of the distance integrand
+        (:math:`k`)""",
 )
 
+GYR_KM_PER_S_MPC = 977.7922216807891  # for converting km/s/Mpc to Gyr
+SPEED_OF_LIGHT_KM_PER_S = 299792.4580  # km/s
 
-def _autodoc(func, strip_wcdm=False, alt=None):
+
+def autodoc(func):
     """
     Simple decorator to mark that a docstring needs formatting
     """
@@ -47,7 +51,7 @@ def _autodoc(func, strip_wcdm=False, alt=None):
     return func
 
 
-def _method_autodoc(strip_wcdm=False, alt=None):
+def method_autodoc(alt=None):
     """
     Simple decorator to mark that a docstring needs formatting.
     This will strip the class level attributes of :code:`FlatwCDM`
@@ -65,8 +69,7 @@ def _method_autodoc(strip_wcdm=False, alt=None):
             doc = alt.__doc__
         else:
             doc = func.__doc__
-        if strip_wcdm:
-            doc = _strip_wcdm_parameters(doc)
+        doc = _strip_wcdm_parameters(doc)
         func.__doc__ = doc
         return func
 
@@ -77,82 +80,14 @@ def maybe_jit(func, *args, **kwargs):
     """
     A decorator to jit the function if using jax.
 
-    This also allows aribtrary arguments to be passed through,
+    This also allows arbitrary arguments to be passed through,
     e.g., to specify static arguments.
 
     This function is pretty useful and so might make it into
     :code:`gwpopulation` regardless of cosmology.
     """
-    from .wcosmo import xp
-
     if "jax" in xp.__name__:
         from jax import jit
 
         return jit(func, *args, **kwargs)
     return func
-
-
-def pade(an, m, n=None):
-    """
-    Return Pade approximation to a polynomial as the ratio of two polynomials.
-
-    Parameters
-    ----------
-    an : (N,) array_like
-        Taylor series coefficients.
-    m : int
-        The order of the returned approximating polynomial `q`.
-    n : int, optional
-        The order of the returned approximating polynomial `p`. By default,
-        the order is ``len(an)-1-m``.
-
-    Returns
-    -------
-    p, q : Polynomial class
-        The Pade approximation of the polynomial defined by `an` is
-        ``p(x)/q(x)``.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy.interpolate import pade
-    >>> e_exp = [1.0, 1.0, 1.0/2.0, 1.0/6.0, 1.0/24.0, 1.0/120.0]
-    >>> p, q = pade(e_exp, 2)
-
-    >>> e_exp.reverse()
-    >>> e_poly = np.poly1d(e_exp)
-
-    Compare ``e_poly(x)`` and the Pade approximation ``p(x)/q(x)``
-
-    >>> e_poly(1)
-    2.7166666666666668
-
-    >>> p(1)/q(1)
-    2.7179487179487181
-
-    Notes
-    -----
-    This code has been slightly edited from the numpy implementation to:
-
-    - Use xp instead of np to support multiple backends
-    - Direclty use the fact that part of the matrix is Toeplitz
-
-    """
-    an = xp.asarray(an)
-    if n is None:
-        n = len(an) - 1 - m
-        if n < 0:
-            raise ValueError("Order of q <m> must be smaller than len(an)-1.")
-    if n < 0:
-        raise ValueError("Order of p <n> must be greater than 0.")
-    N = m + n
-    if N > len(an) - 1:
-        raise ValueError("Order of q+p <m+n> must be smaller than len(an).")
-    an = an[: N + 1]
-    Akj = xp.eye(N + 1, n + 1, dtype=an.dtype)
-    Bkj = toeplitz(xp.r_[0.0, -an[:-1]], xp.zeros(m))
-    Ckj = xp.hstack((Akj, Bkj))
-    pq = xp.linalg.solve(Ckj, an)
-    p = pq[: n + 1]
-    q = xp.r_[1.0, pq[n + 1 :]]
-    return p[::-1], q[::-1]


### PR DESCRIPTION
This PR adds some new functionality. I realised that our method can be applied to any integral of the form $\frac{(1+z)^k}{E(z)}$ so I added absorption distance and lookback time.

I also did some refactoring.