### PR TITLE
FEAT: enable jax units using unxt

### DIFF
--- a/wcosmo/constants.py
+++ b/wcosmo/constants.py
@@ -8,7 +8,10 @@ We include two additional constants that are useful for out default units:
 - :code:`gyr_km_per_s_mpc` - the conversion factor from Gyr to km/s/Mpc
 """
 
+import numpy as xp
 from astropy import units
+
+from .utils import convert_quantity_if_necessary
 
 __all__ = ["USE_UNITS", "c_km_per_s", "gyr_km_per_s_mpc"]
 
@@ -18,7 +21,7 @@ def __getattr__(name):
     if value is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     if USE_UNITS:
-        value = value << _UNITS[name]
+        value = convert_quantity_if_necessary(value, _UNITS[name])
     return value
 
 

--- a/wcosmo/test/test_astropy.py
+++ b/wcosmo/test/test_astropy.py
@@ -5,7 +5,7 @@ def test_astropy_cosmology_not_clobbered():
     """See https://github.com/ColmTalbot/wcosmo/issues/15"""
     import astropy.cosmology
 
-    import wcosmo.astropy
+    import wcosmo.astropy  # noqa
 
     assert "wcosmo" not in astropy.cosmology.Planck15.__module__
 
@@ -16,22 +16,17 @@ def test_jits():
     from astropy.cosmology import FlatLambdaCDM
     from jax import jit
 
-    import wcosmo
     from wcosmo.astropy import FlatwCDM
-    from wcosmo.utils import disable_units
+
+    gwpopulation.set_backend("jax")
 
     @jit
     def test_func(h0):
         cosmo = FlatwCDM(h0, 0.1, -1)
         return cosmo.luminosity_distance(0.1)
 
-    gwpopulation.set_backend("jax")
-    disable_units()
+    my_result = test_func(67.0)
+    their_result = FlatLambdaCDM(67.0, 0.1).luminosity_distance(0.1)
 
-    assert (
-        abs(
-            float(test_func(67.0))
-            - FlatLambdaCDM(67.0, 0.1).luminosity_distance(0.1).value
-        )
-        < 1
-    )
+    assert abs(float(my_result.value) - their_result.value) < 1
+    assert my_result.unit == their_result.unit


### PR DESCRIPTION
Use [unxt](https://unxt.readthedocs.io/en/latest/) to allow units when using the `JAX` backend. This mostly doesn't touch the other backends, although there may be a small performance hit when using numpy.