### PR TITLE
BUG: Fix cupy pade approximant

### DIFF
--- a/wcosmo/backend/__init__.py
+++ b/wcosmo/backend/__init__.py
@@ -1,9 +1,9 @@
 from importlib import import_module
 from importlib.util import find_spec
 
-AVAILABLE_BACKENDS = ["numpy"]
+AVAILABLE_BACKENDS = list()
 
-for backend in ["numpy", "wcosmo.backend.jax", "cupy"]:
+for backend in ["numpy", "wcosmo.backend.jax", "wcosmo.backend.cupy"]:
     if find_spec(backend) is not None:
         if "wcosmo" in backend:
             import_module(backend)

--- a/wcosmo/backend/__init__.py
+++ b/wcosmo/backend/__init__.py
@@ -6,5 +6,8 @@ AVAILABLE_BACKENDS = list()
 for backend in ["numpy", "wcosmo.backend.jax", "wcosmo.backend.cupy"]:
     if find_spec(backend) is not None:
         if "wcosmo" in backend:
-            import_module(backend)
+            try:
+                import_module(backend)
+            except ImportError:
+                continue
         AVAILABLE_BACKENDS.append(backend.split(".")[-1])

--- a/wcosmo/backend/cupy.py
+++ b/wcosmo/backend/cupy.py
@@ -1,0 +1,53 @@
+import cupy as cp
+from cupyx.scipy.linalg import toeplitz
+from plum import dispatch
+
+from ..taylor import pade
+
+
+@pade.dispatch
+def pade(an: cp.ndarray, m, n=None):
+    """
+    Return Pade approximation to a polynomial as the ratio of two polynomials.
+
+    Parameters
+    ----------
+    an : (N,) array_like
+        Taylor series coefficients.
+    m : int
+        The order of the returned approximating polynomial `q`.
+    n : int, optional
+        The order of the returned approximating polynomial `p`. By default,
+        the order is ``len(an)-1-m``.
+
+    Returns
+    -------
+    p, q : Polynomial class
+        The Pade approximation of the polynomial defined by `an` is
+        ``p(x)/q(x)``.
+
+    Notes
+    -----
+    This code has been slightly edited from the scipy implementation to:
+
+    - Use xp instead of np to support multiple backends
+    - Directly use the fact that part of the matrix is Toeplitz
+
+    """
+    if n is None:
+        n = len(an) - 1 - m
+        if n < 0:
+            raise ValueError("Order of q <m> must be smaller than len(an)-1.")
+    if n < 0:
+        raise ValueError("Order of p <n> must be greater than 0.")
+    N = m + n
+    if N > len(an) - 1:
+        raise ValueError("Order of q+p <m+n> must be smaller than len(an).")
+    an = an[: N + 1]
+    Akj = cp.eye(N + 1, n + 1, dtype=an.dtype)
+    Bkj = toeplitz(cp.r_[0.0, -an[:-1]], cp.zeros(m))
+    Ckj = cp.hstack((Akj, Bkj))
+    pq = cp.linalg.solve(Ckj, an)
+    p = pq[: n + 1]
+    q = cp.r_[1.0, pq[n + 1 :]]
+    return p[::-1], q[::-1]

--- a/wcosmo/taylor.py
+++ b/wcosmo/taylor.py
@@ -144,9 +144,9 @@ def indefinite_integral_pade(z, Om0, w0=-1, zpower=0):
     what = (w0 + abs(w0)) / 2
     sign = xp.sign(xp.array(w0))
     abs_sign = abs(sign)
+    Om0 = xp.array(Om0)
     gamma = (Om0 ** (sign - abs_sign) * (1 - Om0) ** (-sign - abs_sign)) ** 0.25
     normalization = -2 * gamma * (1 + z) ** (zpower - 0.5 - 3 * what / 2)
-    Om0 = xp.array(Om0)
     with np.errstate(divide="ignore"):
         x = (Om0 / (1 - Om0)) ** sign * (1 + z) ** (-3 * abs(w0))
     p, q = flat_wcdm_pade_coefficients(w0=w0, zpower=zpower, xp=xp)

--- a/wcosmo/test/test_cosmo.py
+++ b/wcosmo/test/test_cosmo.py
@@ -29,7 +29,6 @@ EPS = 1e-2
 
 def to_numpy(arr):
     xp = array_namespace(arr)
-    print(xp, type(arr), xp.__name__)
     if "cupy" in xp.__name__:
         return arr.get()
     else:

--- a/wcosmo/test/test_cosmo.py
+++ b/wcosmo/test/test_cosmo.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 import numpy as np
@@ -6,7 +7,7 @@ from astropy import cosmology
 from scipy.integrate import IntegrationWarning
 
 from .. import astropy, wcosmo
-from ..utils import disable_units, enable_units, strip_units
+from ..utils import array_namespace, disable_units, enable_units, strip_units
 
 funcs = [
     "luminosity_distance",
@@ -26,6 +27,15 @@ funcs = [
 EPS = 1e-2
 
 
+def to_numpy(arr):
+    xp = array_namespace(arr)
+    print(xp, type(arr), xp.__name__)
+    if "cupy" in xp.__name__:
+        return arr.get()
+    else:
+        return np.asarray(arr)
+
+
 def get_equivalent_cosmologies(cosmo):
     if isinstance(cosmo, str):
         ours = astropy.available[cosmo]
@@ -38,7 +48,7 @@ def get_equivalent_cosmologies(cosmo):
 
 @pytest.mark.parametrize("func", funcs)
 def test_redshift_function(cosmo, func, backend, units, method):
-    if units and ("cupy" in backend.__name__):
+    if (units or method == "analytic") and ("cupy" in backend.__name__):
         pytest.skip()
     xp = backend
 
@@ -77,11 +87,13 @@ def test_redshift_function(cosmo, func, backend, units, method):
     else:
         eps = EPS
     assert isinstance(ours, xp.ndarray)
-    assert max(abs(ours - theirs) / theirs) < eps
+    assert max(abs(to_numpy(ours) - theirs) / theirs) < eps
 
 
 @pytest.mark.parametrize("func", funcs[:3])
 def test_z_at_value(cosmo, func, backend, method):
+    if "cupy" in backend.__name__ and method == "analytic":
+        pytest.skip()
     disable_units()
     xp = backend
 
@@ -106,7 +118,7 @@ def test_z_at_value(cosmo, func, backend, method):
     object.__setattr__(instance, "method", "pade")
 
     assert isinstance(ours, xp.ndarray)
-    assert max(abs(ours - theirs) / theirs) < EPS
+    assert max(abs(to_numpy(ours) - theirs) / theirs) < EPS
 
 
 @pytest.mark.parametrize("func", ["hubble_time", "hubble_distance"])
@@ -148,6 +160,7 @@ def test_dDLdz_is_the_gradient(cosmo):
     is the same as the value obtained with autodiff.
     """
     jax = pytest.importorskip("jax")
+    os.environ["WCOSMO_ARRAY_API"] = "jax"
     enable_units()
 
     ours, _ = get_equivalent_cosmologies(cosmo)


### PR DESCRIPTION
I noticed some type errors and missing cupy pade support after switching to the implicit backends so that adds them. I ran the full numpy+jax+cupy test suite locally.