### PR TITLE
MAINT: verify cupy has a valid cuda environment on import

### DIFF
--- a/wcosmo/backend/cupy.py
+++ b/wcosmo/backend/cupy.py
@@ -1,8 +1,14 @@
 import cupy as cp
+from cupy_backends.cuda.api.runtime import CUDARuntimeError
 from cupyx.scipy.linalg import toeplitz
 from plum import dispatch
 
 from ..taylor import pade
+
+try:
+    cp.cuda.Device()
+except CUDARuntimeError:
+    raise ImportError
 
 
 @pade.dispatch


### PR DESCRIPTION
I noticed that currently the cupy backend will think it imported happily even if there is not an available CUDA runtime.

This tries checking the device and raises an import error if a CUDA error is raised.