### PR TITLE
disable hyp2f1 for jax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest-cov",
-    "jax>=0.4.34",
+    "jax>=0.4.34,<0.4.36",
     "unxt",
 ]
 jax = [
-    "jax>=0.4.34",
+    "jax>=0.4.34,<0.4.36",
     "unxt",
 ]
 

--- a/wcosmo/backend/jax.py
+++ b/wcosmo/backend/jax.py
@@ -70,15 +70,10 @@ def indefinite_integral_hypergeometric(z: jax.Array, Om0, w0=-1, zpower=0):
 def _indefinite_integral_two_component(z, Om0, w0=-1, zpower=0, method="pade"):
     from ..taylor import indefinite_integral_pade
 
-    return jax.lax.cond(
-        method == "pade",
-        indefinite_integral_pade,
-        indefinite_integral_hypergeometric,
-        z,
-        Om0,
-        w0,
-        zpower,
-    )
+    if method != "pade":
+        raise ValueError("wcosmo only supports pade integration with JAX")
+    
+    return indefinite_integral_pade(z, Om0, w0, zpower)
 
 
 @jax.jit

--- a/wcosmo/backend/jax.py
+++ b/wcosmo/backend/jax.py
@@ -72,7 +72,7 @@ def _indefinite_integral_two_component(z, Om0, w0=-1, zpower=0, method="pade"):
 
     if method != "pade":
         raise ValueError("wcosmo only supports pade integration with JAX")
-    
+
     return indefinite_integral_pade(z, Om0, w0, zpower)
 
 

--- a/wcosmo/test/test_cosmo.py
+++ b/wcosmo/test/test_cosmo.py
@@ -47,7 +47,7 @@ def get_equivalent_cosmologies(cosmo):
 
 @pytest.mark.parametrize("func", funcs)
 def test_redshift_function(cosmo, func, backend, units, method):
-    if (units or method == "analytic") and ("cupy" in backend.__name__):
+    if (units or method == "analytic") and (backend != np):
         pytest.skip()
     xp = backend
 
@@ -91,7 +91,7 @@ def test_redshift_function(cosmo, func, backend, units, method):
 
 @pytest.mark.parametrize("func", funcs[:3])
 def test_z_at_value(cosmo, func, backend, method):
-    if "cupy" in backend.__name__ and method == "analytic":
+    if backend != np and method == "analytic":
         pytest.skip()
     disable_units()
     xp = backend


### PR DESCRIPTION
For GPU support I disabled the hypergeometric integration with JAX. For some reason this is introducing a huge bottleneck in some instances.