### PR TITLE
BUG: fix cupy efunc

### DIFF
--- a/wcosmo/wcosmo.py
+++ b/wcosmo/wcosmo.py
@@ -61,6 +61,8 @@ def efunc(z, Om0, w0=-1):
         The E(z) function
     """
     zp1 = 1 + z
+    xp = array_namespace(z)
+    Om0 = xp.asarray(Om0)
     return (Om0 * zp1**3 + (1 - Om0) * zp1 ** (3 * (1 + w0))) ** 0.5
 
 


### PR DESCRIPTION
I'm seeing errors like below when `Om0` is an array

```python
    return (Om0 * zp1**3 + (1 - Om0) * zp1 ** (3 * (1 + w0))) ** 0.5
            ~~~~^~~~~~~~
  File "cupy/_core/core.pyx", line 1746, in cupy._core.core._ndarray_base.__array_ufunc__
  File "cupy/_core/_kernel.pyx", line 1285, in cupy._core._kernel.ufunc.__call__
  File "cupy/_core/_kernel.pyx", line 159, in cupy._core._kernel._preprocess_args
  File "cupy/_core/_kernel.pyx", line 145, in cupy._core._kernel._preprocess_arg
TypeError: Unsupported type <class 'numpy.ndarray'>
```