### PR TITLE
TST: add tests for planck15_lal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ test = [
     "coverage",
     "pre-commit",
     "pytest-cov",
+    'lal; python_version<=3.13',
     'jax>=0.4.34,<0.7; python_version>="3.11"',  # quax is not currently compatible with jax 0.7 (https://github.com/patrick-kidger/quax/issues/71)
     'jax>=0.4.34,<0.6; python_version<"3.11"',  # quaxed has dropped 3.10
     "unxt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ test = [
     "coverage",
     "pre-commit",
     "pytest-cov",
-    'lalsuite; python_version<=3.13',
+    'lalsuite; python_version<="3.13"',
     'jax>=0.4.34,<0.7; python_version>="3.11"',  # quax is not currently compatible with jax 0.7 (https://github.com/patrick-kidger/quax/issues/71)
     'jax>=0.4.34,<0.6; python_version<"3.11"',  # quaxed has dropped 3.10
     "unxt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ test = [
     "coverage",
     "pre-commit",
     "pytest-cov",
-    'lal; python_version<=3.13',
+    'lalsuite; python_version<=3.13',
     'jax>=0.4.34,<0.7; python_version>="3.11"',  # quax is not currently compatible with jax 0.7 (https://github.com/patrick-kidger/quax/issues/71)
     'jax>=0.4.34,<0.6; python_version<"3.11"',  # quaxed has dropped 3.10
     "unxt",

--- a/wcosmo/test/conftest.py
+++ b/wcosmo/test/conftest.py
@@ -19,6 +19,7 @@ test_points = [
     dict(H0=70.0, Om0=0.1, w0=0.0),
     dict(H0=70.0, Om0=0.9, w0=0.0),
     dict(H0=70.0, Om0=1.0, w0=0.0),
+    "Planck15_LAL",
 ]
 
 

--- a/wcosmo/test/test_cosmo.py
+++ b/wcosmo/test/test_cosmo.py
@@ -36,7 +36,20 @@ def to_numpy(arr):
 
 
 def get_equivalent_cosmologies(cosmo):
-    if isinstance(cosmo, str):
+    if cosmo == "Planck15_LAL":
+        ours = astropy.Planck15_LAL
+        try:
+            import lal
+            from astropy import units
+
+            theirs = cosmology.LambdaCDM(
+                H0=lal.H0_SI * units.Hz,
+                Om0=lal.OMEGA_M,
+                Ode0=1 - lal.OMEGA_M,
+            )
+        except ImportError:
+            pytest.skip(f"Bilby not available for {cosmo}")
+    elif isinstance(cosmo, str):
         ours = astropy.available[cosmo]
         theirs = getattr(cosmology, cosmo)
     else:

--- a/wcosmo/test/test_cosmo.py
+++ b/wcosmo/test/test_cosmo.py
@@ -48,7 +48,7 @@ def get_equivalent_cosmologies(cosmo):
                 Ode0=1 - lal.OMEGA_M,
             )
         except ImportError:
-            pytest.skip(f"Bilby not available for {cosmo}")
+            pytest.skip(f"LAL not available for {cosmo}")
     elif isinstance(cosmo, str):
         ours = astropy.available[cosmo]
         theirs = getattr(cosmology, cosmo)


### PR DESCRIPTION
Add tests of Planck15_LAL by directly comparing with lal. I guess this test could fail if the default cosmology in lal updates...